### PR TITLE
Fix: save-mark-and-excursion does not exist until E25.1

### DIFF
--- a/move-text.el
+++ b/move-text.el
@@ -6,7 +6,7 @@
 ;; Keywords: edit
 ;; Url: https://github.com/emacsfodder/move-text
 ;; Compatibility: GNU Emacs 25.1
-;; Version: 2.0.6
+;; Version: 2.0.7
 ;;
 ;;; This file is NOT part of GNU Emacs
 
@@ -83,6 +83,12 @@ them when there's no region."
 (defun move-text--at-penultimate-line-p ()
   "Predicate, is the point at the penultimate line?"
   (= (line-number-at-pos) (1- (move-text--total-lines))))
+
+;; save-mark-and-excursion in Emacs 25 works like save-excursion did before
+(eval-when-compile
+  (when (< emacs-major-version 25)
+    (defmacro save-mark-and-excursion (&rest body)
+      `(save-excursion ,@body))))
 
 ;;;###autoload
 (defun move-text--last-line-is-just-newline ()


### PR DESCRIPTION
Like in https://github.com/magnars/expand-region.el/pull/177