### PR TITLE
Use (use-region-p) instead of mark-active

### DIFF
--- a/move-text.el
+++ b/move-text.el
@@ -66,13 +66,15 @@ Note: `region-beginning' and `region-end' are the reason why an
 
 \"The mark is not set now, so there is no region\"
 
-We check `mark-active' to avoid calling
-them when there's no region.
-We use `prefix-numeric-value' to always return a number and simplify the functions
+We check with `use-region-p' to avoid calling
+them when there's no region or it is not appropriate
+to act on it.
+
+We use `prefix-numeric-value' to return a number.
 "
     (list
-     (when mark-active (region-beginning)) ;; otherwise nil
-     (when mark-active (region-end))
+     (when (use-region-p) (region-beginning)) ;; otherwise nil
+     (when (use-region-p) (region-end))
      (prefix-numeric-value current-prefix-arg)))
 
 ;;;###autoload


### PR DESCRIPTION
This was motivated by a warning from the elisp-compiler on the comment. (use-region-p) is much safer to use than mark-active (my bad). 