### PR TITLE
Add lexical binding to silence native compilation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,14 @@ jobs:
           - 27.1
           - 27.2
           - 28.1
+          - 28.2
+          - 29.1
           - snapshot
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
     - name: Set up Emacs
-      uses: purcell/setup-emacs@v3.0
+      uses: purcell/setup-emacs@master
       with:
         version: ${{ matrix.emacs_version }}
 

--- a/move-text.el
+++ b/move-text.el
@@ -66,13 +66,15 @@ Note: `region-beginning' and `region-end' are the reason why an
 
 \"The mark is not set now, so there is no region\"
 
-We check `mark-active' to avoid calling
-them when there's no region.
-We use `prefix-numeric-value' to always return a number and simplify the functions
+We check with `use-region-p' to avoid calling
+them when there's no region or it is not appropriate
+to act on it.
+
+We use `prefix-numeric-value' to return a number.
 "
     (list
-     (when mark-active (region-beginning)) ;; otherwise nil
-     (when mark-active (region-end))
+     (when (use-region-p) (region-beginning)) ;; otherwise nil
+     (when (use-region-p) (region-end))
      (prefix-numeric-value current-prefix-arg)))
 
 ;;;###autoload

--- a/move-text.el
+++ b/move-text.el
@@ -1,4 +1,4 @@
-;;; move-text.el --- Move current line or region with M-up or M-down.
+;;; move-text.el --- Move current line or region with M-up or M-down. -*- lexical-binding: t; -*-
 
 ;; filename: move-text.el
 ;; Description: Move current line or region with M-up or M-down.


### PR DESCRIPTION
This makes move-text not generate any warnings when native compilation is on.